### PR TITLE
Allow controller name in the metric name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add the filters to your WebApiConfiguration.
             config.ConfigureInstrumentFilters();
             ...
         }
-        
+
         private static void ConfigureInstrumentFilters(this HttpConfiguration config)
         {
             config.Filters.Add(new InstrumentStatusCodeFilterAttribute());

--- a/StatsDHelper.WebApi.Tests.Integration/FakeActionDescriptor.cs
+++ b/StatsDHelper.WebApi.Tests.Integration/FakeActionDescriptor.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+
+namespace StatsDHelper.WebApi.Tests.Integration
+{
+    public class FakeActionDescriptor : HttpActionDescriptor
+    {
+        public FakeActionDescriptor()
+            : base(new HttpControllerDescriptor(new HttpConfiguration(), "ControllerName", typeof(object)))
+        {
+        }
+
+        public override Collection<HttpParameterDescriptor> GetParameters()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<object> ExecuteAsync(HttpControllerContext controllerContext, IDictionary<string, object> arguments, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string ActionName
+        {
+            get { return "ActionName"; }
+        }
+
+        public override Type ReturnType
+        {
+            get { throw new NotImplementedException(); }
+        }
+    }
+}

--- a/StatsDHelper.WebApi.Tests.Integration/HttpActionExecutedContextExtensionsTests.cs
+++ b/StatsDHelper.WebApi.Tests.Integration/HttpActionExecutedContextExtensionsTests.cs
@@ -82,7 +82,7 @@ namespace StatsDHelper.WebApi.Tests.Integration
         [Test]
         public async void when_include_controller_name_is_enabled_then_the_metric_should_include_the_controller_name()
         {
-            _httpActionExecutedContext.InstrumentResponse(includeControllerName: true);
+            _httpActionExecutedContext.InstrumentResponse(template: "{controller}.{action}");
 
             var result = await ListenForStatsDMessage();
 

--- a/StatsDHelper.WebApi.Tests.Integration/HttpActionExecutedContextExtensionsTests.cs
+++ b/StatsDHelper.WebApi.Tests.Integration/HttpActionExecutedContextExtensionsTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 using FluentAssertions;
@@ -20,6 +21,10 @@ namespace StatsDHelper.WebApi.Tests.Integration
     {
         public class FakeActionDescriptor : HttpActionDescriptor
         {
+            public FakeActionDescriptor() : base(new HttpControllerDescriptor(new HttpConfiguration(), "ControllerName", typeof(object)))
+            {
+            }
+
             public override Collection<HttpParameterDescriptor> GetParameters()
             {
                 throw new NotImplementedException();
@@ -44,17 +49,8 @@ namespace StatsDHelper.WebApi.Tests.Integration
         [Test]
         public void when_instrumenting_response_statsd_message_should_be_sent()
         {
-            var port = int.Parse(ConfigurationManager.AppSettings["StatsD.Port"]);
-
-            var actionContext = new HttpActionContext() { ActionDescriptor = new FakeActionDescriptor() };
-
-            var httpActionExecutedContext = new HttpActionExecutedContext
-            {
-                ActionContext = actionContext,
-                Response = new HttpResponseMessage()
-            };
-
-            var task = Task.Factory.StartNew(() => ListenForUdpOnStatsDPort(port));
+            Task<byte[]> task;
+            var httpActionExecutedContext = SetUpFakeHttpActionContext(out task);
 
             httpActionExecutedContext.InstrumentResponse();
 
@@ -65,11 +61,43 @@ namespace StatsDHelper.WebApi.Tests.Integration
             result.Should().Contain("ApplicationName.ActionName.200:1|c");
         }
 
+        private static HttpActionExecutedContext SetUpFakeHttpActionContext(out Task<byte[]> task)
+        {
+            var port = int.Parse(ConfigurationManager.AppSettings["StatsD.Port"]);
+
+            var actionContext = new HttpActionContext {ActionDescriptor = new FakeActionDescriptor()};
+
+            var httpActionExecutedContext = new HttpActionExecutedContext
+            {
+                ActionContext = actionContext,
+                Response = new HttpResponseMessage()
+            };
+
+            task = Task.Factory.StartNew(() => ListenForUdpOnStatsDPort(port));
+            return httpActionExecutedContext;
+        }
+
+        [Test]
+        public void when_include_controller_name_is_enabled_then_the_metric_should_include_the_controller_name()
+        {
+            Task<byte[]> task;
+            var httpActionExecutedContext = SetUpFakeHttpActionContext(out task);
+
+            httpActionExecutedContext.InstrumentResponse(includeControllerName: true);
+
+            task.Wait();
+
+            var result = System.Text.Encoding.UTF8.GetString(task.Result);
+
+            result.Should().Contain("ApplicationName.ControllerName.ActionName.200:1|c");
+        }
+
         private static byte[] ListenForUdpOnStatsDPort(int port)
         {
             var udpClient = new UdpClient(port);
             var ipEndPoint = new IPEndPoint(IPAddress.Loopback, port);
             var data = udpClient.Receive(ref ipEndPoint);
+
             return data;
         }
     }

--- a/StatsDHelper.WebApi.Tests.Integration/StatsDHelper.WebApi.Tests.Integration.csproj
+++ b/StatsDHelper.WebApi.Tests.Integration/StatsDHelper.WebApi.Tests.Integration.csproj
@@ -65,6 +65,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FakeActionDescriptor.cs" />
     <Compile Include="HttpActionExecutedContextExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/StatsDHelper.WebApi.sln
+++ b/StatsDHelper.WebApi.sln
@@ -12,6 +12,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{E8C8F3
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A7C5A393-CDBA-4F33-9522-81AE5278ACBE}"
+	ProjectSection(SolutionItems) = preProject
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/StatsDHelper.WebApi/Filters/HttpActionExecutedContextExtensions.cs
+++ b/StatsDHelper.WebApi/Filters/HttpActionExecutedContextExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Http.Filters;
+﻿using System.Text;
+using System.Web.Http.Filters;
 
 namespace StatsDHelper.WebApi.Filters
 {
@@ -6,12 +7,27 @@ namespace StatsDHelper.WebApi.Filters
     {
         private static readonly IStatsDHelper StatsDHelper = global::StatsDHelper.StatsDHelper.Instance;
 
-        public static void InstrumentResponse(this HttpActionExecutedContext httpActionExecutedContext)
+        public static void InstrumentResponse(this HttpActionExecutedContext httpActionExecutedContext, bool includeActionName = true, bool includeControllerName = false)
         {
             if (httpActionExecutedContext.Response != null)
             {
-                var actionName = httpActionExecutedContext.ActionContext.ActionDescriptor.ActionName;
-                StatsDHelper.LogCount(string.Format("{0}.{1}", actionName, (int)httpActionExecutedContext.Response.StatusCode));
+                var metricNameBuilder = new StringBuilder();
+
+                if (includeControllerName)
+                {
+                    var controllerName = httpActionExecutedContext.ActionContext.ActionDescriptor.ControllerDescriptor.ControllerName;
+                    metricNameBuilder.Append(controllerName);
+                    metricNameBuilder.Append(".");
+                }
+
+                if (includeActionName)
+                {
+                    var actionName = httpActionExecutedContext.ActionContext.ActionDescriptor.ActionName;
+                    metricNameBuilder.Append(actionName);
+                    metricNameBuilder.Append(".");
+                }
+
+                StatsDHelper.LogCount(string.Format("{0}{1}", metricNameBuilder, (int)httpActionExecutedContext.Response.StatusCode));
             }
         }
     }

--- a/StatsDHelper.WebApi/Filters/InstrumentStatusCodeExceptionFilterAttribute.cs
+++ b/StatsDHelper.WebApi/Filters/InstrumentStatusCodeExceptionFilterAttribute.cs
@@ -4,9 +4,16 @@ namespace StatsDHelper.WebApi.Filters
 {
     public class InstrumentStatusCodeExceptionFilterAttribute : ExceptionFilterAttribute
     {
+        private readonly string _template;
+
+        public InstrumentStatusCodeExceptionFilterAttribute(string template = "{action}")
+        {
+            _template = template;
+        }
+
         public override void OnException(HttpActionExecutedContext context)
         {
-            context.InstrumentResponse();
+            context.InstrumentResponse(_template);
 
             base.OnException(context);
         }

--- a/StatsDHelper.WebApi/Filters/InstrumentStatusCodeFilterAttribute.cs
+++ b/StatsDHelper.WebApi/Filters/InstrumentStatusCodeFilterAttribute.cs
@@ -6,9 +6,16 @@ namespace StatsDHelper.WebApi.Filters
 {
     public class InstrumentStatusCodeFilterAttribute : ActionFilterAttribute
     {
+        private readonly string _template;
+
+        public InstrumentStatusCodeFilterAttribute(string template = "{action}")
+        {
+            _template = template;
+        }
+
         public override Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
         {
-            actionExecutedContext.InstrumentResponse();
+            actionExecutedContext.InstrumentResponse(_template);
 
             return base.OnActionExecutedAsync(actionExecutedContext, cancellationToken);
         }


### PR DESCRIPTION
Kept the default {action} naming for backward compatibility's sake, but when new'ing up the attribute for wiring up with webapi, you can supply a template to add {controller} into the metric naming.

Have gone with templating, because using the route template (for cases when the route is different to the controller/action naming, might be a future consideration.
